### PR TITLE
Add options for subtables and multiline text

### DIFF
--- a/app/views/express_mailer/mailer/express.html.erb
+++ b/app/views/express_mailer/mailer/express.html.erb
@@ -27,6 +27,9 @@
     }
   </style>
   <style>
+	 body, html {
+	 	background-color: <%= @attributes.background_color %>;
+	 }
    /* Reset styles */
    body { margin: 0; padding: 0; min-width: 100%; width: 100% !important; height: 100% !important;}
    body, table, td, div, p, a { -webkit-font-smoothing: antialiased; text-size-adjust: 100%; -ms-text-size-adjust: 100%; -webkit-text-size-adjust: 100%; line-height: 100%; }
@@ -78,7 +81,7 @@
 
 <!-- SECTION / BACKGROUND -->
 <!-- Set message background color one again -->
-<table width="100%" align="center" border="0" cellpadding="0" cellspacing="0" style="border-collapse: collapse; border-spacing: 0; margin: 0; padding: 0; padding-bottom: 50px; width: 100%;" class="background"><tr><td align="center" valign="top" style="border-collapse: collapse; border-spacing: 0; margin: 0; padding: 0;"
+<table width="100%" align="center" border="0" cellpadding="0" cellspacing="0" style="border-collapse: collapse; border-spacing: 0; margin: 0; padding: 0; padding-bottom: 50px; width: 100%;" class="background"><tr><td align="center" valign="top" style="border-collapse: collapse; border-spacing: 0; margin: 0; padding: 0; padding-bottom: 50px;"
 	bgcolor="<%= @attributes.background_color %>">
 
 <!-- WRAPPER -->
@@ -137,7 +140,7 @@
 	<% if @attributes.image %>
 		<!-- IMAGE -->
 		<tr>
-			<td align="center" class="color" valign="top" style="border-collapse: collapse; border-spacing: 0; margin: 0; padding: 0; padding-left: 6.25%; padding-right: 6.25%; width: 87.5%; font-size: 14px; font-weight: 400; line-height: 150%; letter-spacing: 2px;
+			<td align="center" class="color" valign="top" style="border-collapse: collapse; border-spacing: 0; margin: 0; padding: 0; padding-left: 6.25%; padding-right: 6.25%; width: 87.5%; font-size: 14px; font-weight: 400; line-height: 150%;
 				padding-bottom: 20px;">
 					<div style="display: inline-block; overflow: hidden; background-color: <%= @attributes.image.background %>;" class="<%= @attributes.image.shape_class %>">
 						<img src="<%= @attributes.image.url %>" alt="<%= @attributes.image.alt %>" height="<%= @attributes.image.height %>" style="float: left;" />
@@ -149,7 +152,7 @@
 	<% if @attributes.headline %>
 		<!-- HEADLINE -->
 		<tr>
-			<td align="center" class="color headline" valign="top" style="border-collapse: collapse; border-spacing: 0; margin: 0; padding: 0; padding-left: 6.25%; padding-right: 6.25%; width: 87.5%; font-size: 60px; font-weight: 600; line-height: 1.1; letter-spacing: 2px;
+			<td align="center" class="color headline" valign="top" style="border-collapse: collapse; border-spacing: 0; margin: 0; padding: 0; padding-left: 6.25%; padding-right: 6.25%; width: 87.5%; font-size: 60px; font-weight: 600; line-height: 1.1;
 				padding-bottom: 20px;
 				font-family: <%= @attributes.headline_font_family %>;">
 					<%= @attributes.headline %>
@@ -164,38 +167,54 @@
 				padding-bottom: 30px; padding-top: 10px; padding-left: 6.25%; padding-right: 6.25%;
 				font-family: <%= @attributes.text_font_family %>;">
 				<table style="width: 100%; border-collapse: collapse; border-spacing: 0; margin: 0; padding: 0;">
+
+					<% @attributes.table.rows.each do |row| %>
+						<% if row[0].is_a?(Array) %>
+							<% row.each do |subrow| %>
+								<tr>
+									<% subrow.each_with_index do |col, idx| %>
+										<td style="text-align: <%= idx == row.count - 1 ? 'right' : 'left' %>; padding-top: 0px; padding-bottom: 12px; padding-left: 8px; padding-right: 8px; font-weight: 400; font-family: <%= @attributes.text_font_family %>; color: <%= @attributes.text_color %>; opacity: 0.7;"><%= col %></td>
+									<% end %>
+								</tr>
+							<% end %>
+						<% else %>
+							<tr>
+								<td align="center" colspan="<%= @attributes.table.column_count %>" valign="top" style="border-collapse: collapse; border-spacing: 0; margin: 0; padding: 0; width: 87.5%;" class="line">
+									<hr color="<%= @attributes.border_color %>" align="center" width="100%" size="1" noshade style="margin: 0; padding: 0;" />
+								</td>
+							</tr>
+							<tr>
+								<% row.each_with_index do |col, idx| %>
+									<td style="text-align: <%= idx == row.count - 1 ? 'right' : 'left' %>; padding-top: 12px; padding-bottom: 12px; padding-left: 8px; padding-right: 8px; font-weight: 600; font-family: <%= @attributes.text_font_family %>; color: <%= @attributes.text_color %>;"><%= col %></td>
+								<% end %>
+							</tr>
+						<% end %>
+					<% end %>
 					<tr>
 			  		<td align="center" colspan="<%= @attributes.table.column_count %>" valign="top" style="border-collapse: collapse; border-spacing: 0; margin: 0; padding: 0; width: 87.5%;" class="line">
 							<hr color="<%= @attributes.border_color %>" align="center" width="100%" size="1" noshade style="margin: 0; padding: 0;" />
 			  		</td>
 			  	</tr>
-					<% @attributes.table.rows.each do |row| %>
-						<tr>
-							<% row.each_with_index do |col, idx| %>
-								<td style="text-align: <%= idx == row.count - 1 ? 'right' : 'left' %>; padding-top: 12px; padding-bottom: 12px; padding-left: 8px; padding-right: 8px; font-weight: 600; font-family: <%= @attributes.text_font_family %>; color: <%= @attributes.text_color %>;"><%= col %></td>
-							<% end %>
-						</tr>
-						<tr>
-							<td align="center" colspan="<%= @attributes.table.column_count %>" valign="top" style="border-collapse: collapse; border-spacing: 0; margin: 0; padding: 0; width: 87.5%;" class="line">
-								<hr color="<%= @attributes.border_color %>" align="center" width="100%" size="1" noshade style="margin: 0; padding: 0;" />
-							</td>
-						</tr>
-					<% end %>
 				</table>
 			</td>
 		</tr>
 	<% end %>
 
-	<% if @attributes.text %>
-	<!-- TEXT -->
-	<tr>
-		<td align="<%= @attributes.text_align %>" valign="top" style="border-collapse: collapse; border-spacing: 0; margin: 0; padding: 0; padding-left: 6.25%; padding-right: 6.25%; width: 87.5%; font-size: <%= @attributes.text_size %>px; font-weight: 400; line-height: 1.3;
-			padding-bottom: 20px;
-			color: <%= @attributes.text_color %>;
-			font-family: <%= @attributes.text_font_family %>;" class="paragraph">
-				<%= @attributes.text %>
-		</td>
-	</tr>
+	<% if @attributes.text.present? %>
+		<!-- TEXT -->
+		<% @attributes.text.split("\n").each do |line| %>
+			<tr style="padding-top: 10px;">
+				<td align="<%= @attributes.text_align %>" valign="top" style="border-collapse: collapse; border-spacing: 0; margin: 0; padding: 0; padding-left: 6.25%; padding-right: 6.25%; width: 87.5%; font-size: <%= @attributes.text_size %>px; font-weight: 400; line-height: 1.3;
+					padding-bottom: 0;
+					color: <%= @attributes.text_color %>;
+					font-family: <%= @attributes.text_font_family %>;" class="paragraph">
+						<%= line %>&nbsp;
+				</td>
+			</tr>
+		<% end %>
+		<tr>
+			<td style="height: 20px; border-collapse: collapse; border-spacing: 0; margin: 0; padding: 0;"></td>
+		</tr>
 	<% end %>
 
 	<% if @attributes.button %>

--- a/lib/express_mailer/version.rb
+++ b/lib/express_mailer/version.rb
@@ -1,3 +1,3 @@
 module ExpressMailer
-  VERSION = "0.1.1"
+  VERSION = "0.1.2"
 end

--- a/test/dummy/test/mailers/previews/express_mailer_preview.rb
+++ b/test/dummy/test/mailers/previews/express_mailer_preview.rb
@@ -11,10 +11,11 @@ class ExpressMailerPreview < ActionMailer::Preview
       headline: '$2,400',
       table: [
         ['Acme Corporation', '$1200'],
+        [['Days Remaining', '28'], ['Renewal Rate', '10%']],
         ['Enterprise LLC', '$600'],
         ['Corner Market', '$600'],
       ],
-      text: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Fusce eget ex ullamcorper, dapibus mauris euismod, ultrices elit.',
+      text: "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Fusce eget ex ullamcorper.\nDapibus mauris euismod, ultrices elit.",
       button: {
         text: 'View details',
         href: 'http://example.com/orders/1'


### PR DESCRIPTION
Table rows can now be arrays themselves which will make 'subtable' style rows for defining metadata on a row.

Also, newlines are converted properly in the text attribute.